### PR TITLE
removed extra space from vanilla-router.js

### DIFF
--- a/src/vanilla-router.js
+++ b/src/vanilla-router.js
@@ -2,16 +2,13 @@ import Utils from './modules/Utils.js'
 import { RouterPage, RouterRoot } from './modules/routerDom.js'
 import RouterHandle from './modules/routerHandle.js'
 
-
 // Add data-root attribute coming from <router-root> element to options object in Utils.js
 const root = document.querySelector('router-root')
 Utils.options.root = root.getAttribute('data-root')
 
-
 // Defining HTML elements that can be used as <router-root> and <router-page>
 customElements.define('router-page', RouterPage)
 customElements.define('router-root', RouterRoot)
-
 
 const handleLinks = (e) => {
     const target = e.target
@@ -28,7 +25,6 @@ const handleLinks = (e) => {
 
 // Listen event for link clicks
 window.addEventListener('click', handleLinks)
-
 
 // Listen events for routing
 window.addEventListener('popstate', RouterHandle.handle)


### PR DESCRIPTION
The two lines spaces were reduced to one line space.